### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import find_packages, setup
 
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
+with open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf-8') as readme:
     README = readme.read()
 
 # allow setup.py to be run from any path


### PR DESCRIPTION
readme.rst is encoded in utf-8, which will cause error when installed in a non-utf8-default environment.